### PR TITLE
Connected to device attribute

### DIFF
--- a/custom_components/amplifi/coordinator.py
+++ b/custom_components/amplifi/coordinator.py
@@ -73,6 +73,7 @@ class AmplifiDataUpdateCoordinator(DataUpdateCoordinator):
                             device_info = raw_wifi_devices[access_point][wifi_band][
                                 network_type
                             ][macAddr]
+                            device_info["connected_to"] = access_point
                             wifi_devices[macAddr] = device_info
 
         self._wifi_devices = wifi_devices

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,8 +131,8 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
-    def hostname(self):
-        """Return hostname of the device."""
+    def connected_to(self):
+        """Return mac address of the AP this device is connected to."""
         if "connected_to" in self._data:
             return self._data["connected_to"]
 

--- a/custom_components/amplifi/device_tracker.py
+++ b/custom_components/amplifi/device_tracker.py
@@ -131,6 +131,14 @@ class AmplifiWifiDeviceTracker(CoordinatorEntity, ScannerEntity):
         return None
 
     @property
+    def hostname(self):
+        """Return hostname of the device."""
+        if "connected_to" in self._data:
+            return self._data["connected_to"]
+
+        return None
+
+    @property
     def extra_state_attributes(self):
         """Return extra attributes."""
         if self.coordinator.last_update_success and self._data is not None:

--- a/custom_components/amplifi/manifest.json
+++ b/custom_components/amplifi/manifest.json
@@ -12,5 +12,5 @@
   "codeowners": [
     "@puttyman"
   ],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }


### PR DESCRIPTION
Appends a "connected_to" attribute to the list of attributes for the device_tracker entity

The format of info-async.php is such that each connected device is listed beneath the MAC address of the AP is it connected to. We can simply return this as we do with other attributes. This can then be used in a markdown card with a configuration such as:
```jinja2
Mesh Point 1
{% for item in (states.device_tracker
|selectattr('entity_id', 'match', 'device_tracker.amplifi.*')
|selectattr('state', 'eq', 'home')
|map(attribute='entity_id')) %}
{% if (state_attr(item,'connected_to') == 'f0:9f:c2:xx:xx:xx') %}
* {{ item.replace('device_tracker.amplifi_','') }} 
{% endif %}
{% endfor %}
```

which gives you a result such as:
![image](https://github.com/hawksj/hass-amplifi/assets/58028821/4bdba392-31dc-4674-90ed-1db2d55cdbf8)